### PR TITLE
fix - documentation (reorganization, fw vs runtime, badges)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ docs/build
 .vscode/
 *.pyc
 docs/source/branch
+
+docs/source/_build/html/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## GiggleBot MicroPython for the BBC Micro:bit 
-[![Build Status](https://travis-ci.org/RobertLucian/micropython-gigglebot.svg?branch=master)](https://travis-ci.org/RobertLucian/micropython-gigglebot) [![Documentation Status](https://readthedocs.org/projects/gigglebot-dev/badge/?version=develop)](https://gigglebot-dev.readthedocs.io/en/develop/?badge=develop)
+[![Build Status](https://travis-ci.org/DexterInd/micropython-gigglebot.svg?branch=master)](https://travis-ci.org/DexterInd/micropython-gigglebot) [![Documentation Status](https://readthedocs.org/projects/gigglebot/badge/?version=stable)](https://gigglebot.readthedocs.io/en/stable/?badge=stable)
 
 This is the repository for the MicroPython that's running on the BBC micro:bit + GiggleBot robot.
 

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -1,7 +1,10 @@
 v1.0.0:
   title: GiggleBot MicroPython Firmware v1.0.0
   body:
-    - official release.
+    - Update build/docs badges on the project's README.
+    - Mention the removal of the compass and SPI libraries.
+    - Clarify the difference between the MicroPython and DAPLink firmwares.
+    - Reorganize the documentation a little bit.
 v0.4.0:
   title: GiggleBot MicroPython Firmware v0.4.0
   body:

--- a/docs/source/firmware.rst
+++ b/docs/source/firmware.rst
@@ -31,8 +31,10 @@ Firmware
 
 This customized firmware that includes the modules listed in this documentation also includes a handful of features meant to make use
 of the available RAM on the BBC micro:bit in a more efficient manner. 
+The downside to this, is that we had to remove the built-in support for the micro:bit's compass and the SPI libraries, which are not
+going to be used anyway.
 
-The default micrpython runtime that comes with the Mu Editor fills the needs of a single microbit but does not offer enough power to easily drive extra hardware like the GiggleBot. So we have come up with a custom firmware that allows the import of precompiled python modules (to byte-code aka ``.mpy`` files). These ``.mpy`` modules can be treated
+The default micropython runtime that comes with the Mu Editor fills the needs of a single microbit but does not offer enough power to easily drive extra hardware like the GiggleBot. So we have come up with a custom firmware that allows the import of precompiled python modules (to byte-code aka ``.mpy`` files). These ``.mpy`` modules can be treated
 like regular ``.py`` modules and copied in exactly the same manner over your microbit's filesystem, but they cannot be opened and edited in any way; it's not like it's necessary anyway.
 This has the advantage of skipping the precompiling phase on the microbit that could leave it without RAM resources during or after this process. 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,11 +26,11 @@ For an introduction to MicroPython on the Micro:Bit, see the `official tutorial 
    quickstart
    firmware
 
+   code
+
    control-tutorial
    sensors-tutorial
    addon-sensors-tutorial
-
-   code
 
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -26,6 +26,23 @@ At the end of these short instructions, you will be able to run the following sn
         sleep(250) # wait 250 msec
         pixels_off() # turn off the GiggleBot eyes
         sleep(250) # wait 250 msec
+
+
+.. note::
+
+    There are 2 MCUs sitting on the BBC micro:bit:
+
+    * One MCU has the role of flashing the HEX file that gets copied over to the other MCU.
+    * And the second MCU houses the actual scripts and MicroPython firmware that you interact with (in the real world or at the terminal).
+
+    Both of these MCUs have their own firmware, but sometimes the firmware sitting on the MCU that hosts the scripts and the MicroPython firmware gets to be called a *runtime*. Other
+    times it's just called for what it is - a firmware, just like in the following examples:
+    
+    * `Exhibit A <https://microbit-micropython.readthedocs.io/en/v1.0.1/devguide/flashfirmware.html?highlight=firmware#>`_ from BBC micro:bit MicroPython docs.
+    * `Exhibit B <https://microbit-micropython.readthedocs.io/en/v1.0.1/devguide/hexformat.html>`_ from BBC micro:bit MicroPython docs.
+
+    So in our documentation, when we talk about the firmware, we are referring to the MicroPython firmware. And when we want to refer to the other MCU's firmware,
+    we just call it the DAPLink firmware. Simple, right?
       
 
 ************************


### PR DESCRIPTION
- Update build/docs badges on the project's README.
- Mention the removal of the compass and SPI libraries.
- Clarify the difference between the MicroPython and DAPLink firmwares.
- Reorganize the documentation a little bit.